### PR TITLE
Feature/id 5 lka

### DIFF
--- a/src/AutomatedCar/Models/AutomatedCar.cs
+++ b/src/AutomatedCar/Models/AutomatedCar.cs
@@ -73,13 +73,17 @@ namespace AutomatedCar.Models
             };
             this.RadarSensor = new RadarSensor(radarSettings);
             this.CameraSensor = new CameraSensor(cameraSettings);
-            this.CollSensor = new CollisionSensor(virtualFunctionBus,this);
+            this.CollSensor = new CollisionSensor(this.virtualFunctionBus, this);
+            this.LKA = new LaneKeepingAssistance(this, this.CameraSensor, this.virtualFunctionBus);
         }
 
         public RadarSensor RadarSensor { get;  }
 
         public CameraSensor CameraSensor { get; }
+
         public CollisionSensor CollSensor { get; }
+
+        public LaneKeepingAssistance LKA { get; }
 
         public VirtualFunctionBus VirtualFunctionBus { get => this.virtualFunctionBus; }
         private void NotifyPropertyChanged([CallerMemberName] string propertyName = "") => this.PropertyChanged?.Invoke(this, new(propertyName));

--- a/src/AutomatedCar/SystemComponents/LaneKeepingAssistance.cs
+++ b/src/AutomatedCar/SystemComponents/LaneKeepingAssistance.cs
@@ -1,39 +1,102 @@
 ﻿namespace AutomatedCar.SystemComponents
 {
-    using AutomatedCar.SystemComponents.Packets;
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
+    using AutomatedCar.Helpers;
+    using AutomatedCar.Models;
+    using AutomatedCar.SystemComponents.Packets;
+    using Avalonia;
+    using Avalonia.Media;
 
     public class LaneKeepingAssistance : SystemComponent
     {
+        private static readonly string[] INVALID_ROADTYPES = {
+            "road_2lane_rotary.png",
+            "road_2lane_tjunctionleft.png",
+            "road_2lane_tjunctionright.png",
+            "road_2lane_crossroad_1.png",
+            "road_2lane_crossroad_2.png",
+        };
+
         private LKAPacket packet;
+        private CameraSensor cameraSensor;
+        private AutomatedCar car;
+
         private LKANotifierPacket notifierPacket;
         public bool isEnabled { get; set; }
+
+        public LaneKeepingAssistance(AutomatedCar car, CameraSensor cameraSensor, VirtualFunctionBus virtualFunctionBus)
+            : base(virtualFunctionBus)
+        {
+            this.cameraSensor = cameraSensor;
+            this.car = car;
+
+            this.packet = new LKAPacket();
+            this.packet.recommendedTurnAngle = 0;
+            this.virtualFunctionBus.LaneKeepingPacket = this.packet;
+        }
+
         public bool canBeEnabled()
         {
             // egyelore csak
             // hogy buildeljen
             return true;
-
         }
 
-        public LaneKeepingAssistance(VirtualFunctionBus virtualFunctionBus) : base(virtualFunctionBus)
+        public override void Process()
         {
+            this.packet.recommendedTurnAngle = this.GetRecommendedTurnAngle();
+        }
+
+        public Point GetLaneCenterPoint(List<DetectedObjectInfo> lanes)
+        {
+            lanes = lanes?.OrderBy(x => x.Distance).Take(2).ToList();
+            double x1, y1, x2, y2;
+            x1 = lanes[0].DetectedObject.X;
+            y1 = lanes[0].DetectedObject.Y;
+            x2 = lanes[1].DetectedObject.X;
+            y2 = lanes[1].DetectedObject.Y;
+
+            return new Point((x1 + x2) / 2, (y1 + y2) / 2);
+        }
+
+        public List<DetectedObjectInfo> GetLanes()
+        {
+            List<DetectedObjectInfo> detectedObjects = new List<DetectedObjectInfo>();
+            PolylineGeometry sensor = new PolylineGeometry(this.cameraSensor.GenerateSensorTriangle(), false);
+            var filteredWorldObjects = World.Instance.WorldObjects.Where(obj => obj.WorldObjectType == WorldObjectType.Road
+            && !INVALID_ROADTYPES.Contains(obj.Filename)
+            && !obj.Equals(this.car));
 
             this.packet= new LKAPacket();
             notifierPacket= new LKANotifierPacket();
 
             virtualFunctionBus.LKANotifierPacket = this.notifierPacket;
+            this.cameraSensor.DetectObjects(detectedObjects, sensor, filteredWorldObjects);
 
-            packet.recommendedTurnAngle=0;
-            virtualFunctionBus.LaneKeepingPacket= packet;
+            return detectedObjects;
         }
-        public override void Process()
+
+        // More debug needed
+        public double GetRecommendedTurnAngle()
         {
-            throw new NotImplementedException();
+            var lanes = this.GetLanes();
+            if (lanes.Count < 2)
+            {
+                return double.NaN;
+            }
+
+            Point targetPoint = this.GetLaneCenterPoint(lanes);
+
+            double targetRotation = GeometryUtils.GetRotation(
+                GeometryUtils.RadToDeg(
+                    GeometryUtils.GetAngle(targetPoint, new Point(this.car.X, this.car.Y))));
+
+            double recommendedTurnAngle = targetRotation - this.car.Rotation;
+            return (Math.Abs(recommendedTurnAngle) <= 45) ? recommendedTurnAngle : double.NaN;
         }
     }
 }

--- a/src/AutomatedCar/SystemComponents/LaneKeepingAssistance.cs
+++ b/src/AutomatedCar/SystemComponents/LaneKeepingAssistance.cs
@@ -35,7 +35,10 @@
             this.car = car;
 
             this.packet = new LKAPacket();
-            this.packet.recommendedTurnAngle = 0;
+            this.notifierPacket = new LKANotifierPacket();
+
+            virtualFunctionBus.LKANotifierPacket = this.notifierPacket;
+            this.packet.recommendedTurnAngle = double.NaN;
             this.virtualFunctionBus.LaneKeepingPacket = this.packet;
         }
 
@@ -71,10 +74,6 @@
             && !INVALID_ROADTYPES.Contains(obj.Filename)
             && !obj.Equals(this.car));
 
-            this.packet= new LKAPacket();
-            notifierPacket= new LKANotifierPacket();
-
-            virtualFunctionBus.LKANotifierPacket = this.notifierPacket;
             this.cameraSensor.DetectObjects(detectedObjects, sensor, filteredWorldObjects);
 
             return detectedObjects;


### PR DESCRIPTION
**LaneKeepingAssistance osztály megvalósítása:**

- GetLaneCenterPoint és GetRecommendedTurnAngle() áthelyezve GenericSensorból ebbe az osztályba
- ezzel együtt refaktorálva a GenericSensor és a jelen osztály is
- GetLaneCenterPoint átalakítva, úgy hogy kezelni tudja azt is, ha nem talál (elég) sávot
- GetLaneCenterPoint kiegészítve a nem (igazán) kezelhető utak szűrésével
- LaneKeepingAssistance osztály konstruktorának átalakítása
- Process() a csomagra rakja a szükséges kormányzás szögét
- Alapesetben a korábbi 0 helyett, a recommendedTurnAngle értékek double.NaN
- Ugyanígy, ha az útszakasz nem tisztán érzékelhető vagy kezelhető, a visszaadott érték double.NaN
- Ha a szükséges kormányszög meghaladja a + vagy -45 fokot, szintént double.NaN a visszatérési érték