### PR TITLE
Fix ProcessInformation() in GenericSensor:

### DIFF
--- a/src/AutomatedCar/SystemComponents/GenericSensor.cs
+++ b/src/AutomatedCar/SystemComponents/GenericSensor.cs
@@ -119,10 +119,11 @@
 
         private void ProcessInformation(WorldObject worldObject, Point transformedPoint, List<DetectedObjectInfo> detectedObjects)
         {
+            Point anchorPoint = GeometryUtils.TransformPoint(this.CarAnchorPoint, this.Car);
             DetectedObjectInfo newInfo = new DetectedObjectInfo()
             {
                 DetectedObject = worldObject,
-                Distance = (float)GeometryUtils.GetEuclidianDistance(transformedPoint, this.CarAnchorPoint + new Point(this.Car.X, this.Car.Y)),
+                Distance = (float)GeometryUtils.GetEuclidianDistance(transformedPoint, anchorPoint),
             };
             if (!detectedObjects.Contains(newInfo))
             {


### PR DESCRIPTION
GenericSensor osztály ProcessInformation() metódusásban most már maga az anchorPoint transzformációra kerül.